### PR TITLE
Add handler collection

### DIFF
--- a/src/Handler.ts
+++ b/src/Handler.ts
@@ -9,43 +9,70 @@ export class Handler<ResponseBody = unknown, RequestPayload = unknown> {
 
   private params?: RequestParameters
 
-  private responseBody?: ResponseBody
-
-  private responseCode = 200
-
   private requestPayload?: RequestPayload
 
-  setMethod(method: RESTMethods) {
-    this.method = method
-    return this
-  }
+  private responseStatusCode = 200
 
-  setUrl(url: string) {
+  private responseBody?: ResponseBody
+
+  name: string | null = null
+
+  public on(method: RESTMethods | keyof typeof RESTMethods, url: string) {
+    this.method = typeof method === 'string' ? RESTMethods[method] : method
     this.url = url
     return this
   }
 
-  setRequestParams(params: RequestParameters) {
+  public onGet(url: string) {
+    return this.on(RESTMethods.GET, url)
+  }
+
+  public onPost(url: string) {
+    return this.on(RESTMethods.POST, url)
+  }
+
+  public onPatch(url: string) {
+    return this.on(RESTMethods.PATCH, url)
+  }
+
+  public onPut(url: string) {
+    return this.on(RESTMethods.PUT, url)
+  }
+
+  public onOptions(url: string) {
+    return this.on(RESTMethods.OPTIONS, url)
+  }
+
+  public onHead(url: string) {
+    return this.on(RESTMethods.HEAD, url)
+  }
+
+  public onDelete(url: string) {
+    return this.on(RESTMethods.DELETE, url)
+  }
+
+  withParams(params: RequestParameters) {
     this.params = params
     return this
   }
 
-  setRequestPayload<Payload extends RequestPayload>(payload: Payload) {
+  withPayload<Payload extends RequestPayload>(payload: Payload) {
     this.requestPayload = payload
     return this as unknown as Handler<ResponseBody, Payload>
   }
 
-  setResponseCode(statusCode: number) {
-    this.responseCode = statusCode
-    return this
-  }
-
-  setResponseBody<Body extends ResponseBody>(response: Body) {
-    this.responseBody = response
+  public reply<Body extends ResponseBody>(status: number, body?: Body) {
+    this.responseStatusCode = status
+    this.responseBody = body
     return this as unknown as Handler<Body, RequestPayload>
   }
 
-  handle() {
+  as(name: string) {
+    this.name = name
+    return this
+  }
+
+  run() {
     if (!this.url) throw new Error('No url provided')
 
     return new RestHandler(this.method, this.url, (req, res, context) => {
@@ -58,7 +85,7 @@ export class Handler<ResponseBody = unknown, RequestPayload = unknown> {
       }
 
       return res(
-        context.status(this.responseCode),
+        context.status(this.responseStatusCode),
         context.json(this.responseBody),
       )
     })

--- a/src/HandlerCollection.test.ts
+++ b/src/HandlerCollection.test.ts
@@ -1,0 +1,54 @@
+import { Handler } from './Handler'
+import { HandlerCollection } from './HandlerCollection'
+
+it('should be able to collect a single handler', () => {
+  const getAllUsersHandler = new Handler()
+    .onGet('/user')
+    .reply(200)
+    .as('getUsers')
+
+  const collection = new HandlerCollection()
+  collection.collect(getAllUsersHandler)
+
+  expect(collection.find('getUsers')).toEqual(getAllUsersHandler)
+})
+
+it('should be able to collect multiple handlers', () => {
+  const getAllUsersHandler = new Handler()
+    .onGet('/user')
+    .reply(200)
+    .as('getUsers')
+
+  const registrationHandler = new Handler()
+    .onPost('/register')
+    .reply(200, {
+      success: true,
+      message: 'users registered successfully.',
+    })
+    .as('register')
+
+  const collection = new HandlerCollection()
+  collection.collect(getAllUsersHandler, registrationHandler)
+
+  expect(collection.find('getUsers')).toEqual(getAllUsersHandler)
+  expect(collection.find('register')).toEqual(registrationHandler)
+})
+
+it('should trow appropriate error when the handler does not have a name', () => {
+  const handlerWithoutName = new Handler().onGet('/user').reply(200)
+
+  const collection = new HandlerCollection()
+
+  expect(() => collection.collect(handlerWithoutName)).toThrowError(
+    'Lyrebird: Each handler should contain a name to be stored in the collection. \n' +
+      'For future reference, name your handler using the `as("...")` method',
+  )
+})
+
+it('should trow appropriate error requested handler does not exist in the collection', () => {
+  const collection = new HandlerCollection()
+
+  expect(() => collection.find('invalidHandler')).toThrowError(
+    `Lyrebird: No Handler found with the given name \`invalidHandler\` in the collection.`,
+  )
+})

--- a/src/HandlerCollection.ts
+++ b/src/HandlerCollection.ts
@@ -1,0 +1,38 @@
+import { Handler } from './Handler'
+
+export class HandlerCollection {
+  private collection: Map<string, Handler>
+
+  constructor() {
+    this.collection = new Map<string, Handler>()
+  }
+
+  collect(...handlers: Array<Handler>): void {
+    handlers.forEach((handler) => {
+      const key = handler.name
+
+      if (!key) {
+        throw new Error(
+          '\n' +
+            'Lyrebird: Each handler should contain a name to be stored in the collection. \n' +
+            'For future reference, name your handler using the `as("...")` method',
+        )
+      }
+
+      this.collection.set(key, handler)
+    })
+  }
+
+  find(name: string): Handler {
+    const handler = this.collection.get(name)
+
+    if (!handler) {
+      throw new Error(
+        '\n' +
+          `Lyrebird: No Handler found with the given name \`${name}\` in the collection.`,
+      )
+    }
+
+    return handler
+  }
+}

--- a/src/MockServer.test.ts
+++ b/src/MockServer.test.ts
@@ -1,7 +1,8 @@
 import axios from 'axios'
-import { RESTMethods } from 'msw'
 import { setupServer } from 'msw/node'
 import { MockServer } from './MockServer'
+import { HandlerCollection } from './HandlerCollection'
+import { Handler } from './Handler'
 
 const mockServer = setupServer()
 
@@ -9,147 +10,139 @@ beforeAll(() => mockServer.listen())
 afterAll(() => mockServer.close())
 afterEach(() => mockServer.resetHandlers())
 
-const server = new MockServer(mockServer)
+const collection = new HandlerCollection()
 
-describe('Intercepting HTTP Methods', () => {
-  it.each([
-    ['get', RESTMethods.GET],
-    ['post', RESTMethods.POST],
-    ['put', RESTMethods.PUT],
-    ['patch', RESTMethods.PATCH],
-    ['head', RESTMethods.HEAD],
-    ['options', RESTMethods.OPTIONS],
-    ['delete', RESTMethods.DELETE],
-  ] as const)(
-    'should be able to intercept `%s` requests',
-    async (method, RESTMethod) => {
-      const serverResponse = { message: 'request received successfully' }
-
-      server.on(RESTMethod, '/endpoint').reply(200, serverResponse)
-
-      const { data } = await axios[method]('/endpoint')
-
-      expect(data).toEqual(serverResponse)
-    },
-  )
-})
-
-it('response body is optional', async () => {
-  server.onGet('/test').reply(200)
-
-  const { data, status } = await axios.get('/test')
-
-  expect(status).toEqual(200)
-  expect(data).toEqual('')
-})
-
-describe('withPayload', () => {
-  it('should be able to intercept requests with constrained request payload', async () => {
-    server
-      .onPost('/register')
-      .withPayload({ email: 'user@example.com', password: 'secret' })
-      .reply(200, { success: true, message: 'User registered successfully.' })
-
-    const { data, status } = await axios.post('/register', {
-      email: 'user@example.com',
-      password: 'secret',
+collection.collect(
+  new Handler()
+    .onGet('/users')
+    .reply(200, {
+      users: [],
     })
+    .as('getAllUsers'),
 
-    expect(status).toEqual(200)
-    expect(data).toEqual({
+  new Handler()
+    .onPost('/register')
+    .reply(200, {
       success: true,
-      message: 'User registered successfully.',
+      message: 'users registered successfully.',
     })
+    .as('register'),
+)
 
-    await expect(async () => {
-      await axios.post('/register', {
-        email: 'user@example.com',
-      })
-    }).rejects.toThrowError()
+const server = new MockServer(mockServer, { collection })
+
+describe('Using a collection', () => {
+  it('should be able to get and enable a handler from collection', async () => {
+    server.use('getAllUsers')
+
+    const { data } = await axios.get('/users')
+    expect(data).toEqual({ users: [] })
   })
 
-  it('should be able to intercept multiple requests with constrained request payload using the same instance', async () => {
-    server
-      .onPost('/register')
-      .withPayload({ email: 'user@example.com', password: 'secret' })
-      .reply(200, { success: true, message: 'User registered successfully.' })
+  it('should be able to get and enable multiple handlers from collection', async () => {
+    server.use('getAllUsers')
+    server.use('register')
 
-    server
-      .onPost('/posts')
-      .withPayload({ title: 'New post.', content: 'Hello world.' })
-      .reply(201, { success: true, message: 'Post created successfully.' })
+    const { data: users } = await axios.get('/users')
+    expect(users).toEqual({ users: [] })
 
-    const registrationResponse = await axios.post('/register', {
-      email: 'user@example.com',
-      password: 'secret',
-    })
-
-    expect(registrationResponse.status).toEqual(200)
-    expect(registrationResponse.data).toEqual({
+    const { data: registrationResult } = await axios.post('/register')
+    expect(registrationResult).toEqual({
       success: true,
-      message: 'User registered successfully.',
+      message: 'users registered successfully.',
     })
+  })
 
-    const createPostResponse = await axios.post('/posts', {
-      title: 'New post.',
-      content: 'Hello world.',
-    })
+  it('should be able to get and enable multiple handlers from collection at once', async () => {
+    server.use('getAllUsers', 'register')
 
-    expect(createPostResponse.status).toEqual(201)
-    expect(createPostResponse.data).toEqual({
+    const { data: users } = await axios.get('/users')
+    expect(users).toEqual({ users: [] })
+
+    const { data: registrationResult } = await axios.post('/register')
+    expect(registrationResult).toEqual({
       success: true,
-      message: 'Post created successfully.',
+      message: 'users registered successfully.',
+    })
+  })
+
+  it('should throw an error when using handler names while no collection is provided', () => {
+    expect(() => new MockServer(mockServer).use('handler')).toThrowError(
+      `Lyrebird: Unable to find handler \`handler\` because there isn't a HandlerCollection ` +
+        `associated with the current MockServer instance. Please consider creating a HandlerCollection ` +
+        `or using an inline handler instead.`,
+    )
+  })
+
+  it('should be possible to use `enable` as an alias for `use` to enable collection mocks', async () => {
+    server.enable('getAllUsers', 'register')
+
+    const { data: users } = await axios.get('/users')
+    expect(users).toEqual({ users: [] })
+
+    const { data: registrationResult } = await axios.post('/register')
+    expect(registrationResult).toEqual({
+      success: true,
+      message: 'users registered successfully.',
     })
   })
 })
 
-describe('withParams', () => {
-  it('should be able to intercept a request with the constrained request params', async () => {
-    server
-      .onGet('/users')
-      .withParams({ admin: 'true' })
-      .reply(200, { success: true, users: {} })
+describe('Using inline handlers', () => {
+  it('should be able to enable an inline handler', async () => {
+    server.use(
+      new Handler().onGet('/users').reply(200, {
+        users: [],
+      }),
+    )
 
-    const { data, status } = await axios.get('/users?admin=true')
-
-    expect(status).toEqual(200)
-    expect(data).toEqual({ success: true, users: {} })
-
-    await expect(async () => {
-      await axios.get('/users')
-    }).rejects.toThrowError()
+    const { data } = await axios.get('/users')
+    expect(data).toEqual({ users: [] })
   })
 
-  it('should be able to intercept multiple requests with constrained request params using the same instance', async () => {
-    server
-      .onGet('/users')
-      .withParams({ admin: 'true' })
-      .reply(200, { success: true, users: {} })
+  it('should be able to enable multiple inline handlers', async () => {
+    server.use(
+      new Handler().onGet('/users').reply(200, {
+        users: [],
+      }),
+    )
 
-    server
-      .onGet('/posts')
-      .withParams({ published: 'false' })
-      .reply(200, { success: true, count: 3, posts: {} })
+    server.use(
+      new Handler().onPost('/register').reply(200, {
+        success: true,
+        message: 'users registered successfully.',
+      }),
+    )
 
-    const { data: users } = await axios.get('/users?admin=true')
-    expect(users).toEqual({ success: true, users: {} })
+    const { data: users } = await axios.get('/users')
+    expect(users).toEqual({ users: [] })
 
-    const { data: posts } = await axios.get('/posts?published=false')
-    expect(posts).toEqual({ success: true, count: 3, posts: {} })
+    const { data: registrationResult } = await axios.post('/register')
+    expect(registrationResult).toEqual({
+      success: true,
+      message: 'users registered successfully.',
+    })
   })
 
-  it('should be possible to intercept multiple requests with and without constrained params', async () => {
-    server
-      .onGet('/users')
-      .withParams({ admin: 'true' })
-      .reply(200, { success: true, users: {} })
+  it('should be able to enable multiple inline handlers at once', async () => {
+    server.use(
+      new Handler().onGet('/users').reply(200, {
+        users: [],
+      }),
 
-    server.onGet('/posts').reply(200, { success: true, count: 3, posts: {} })
+      new Handler().onPost('/register').reply(200, {
+        success: true,
+        message: 'users registered successfully.',
+      }),
+    )
 
-    const { data: users } = await axios.get('/users?admin=true')
-    expect(users).toEqual({ success: true, users: {} })
+    const { data: users } = await axios.get('/users')
+    expect(users).toEqual({ users: [] })
 
-    const { data: posts } = await axios.get('/posts')
-    expect(posts).toEqual({ success: true, count: 3, posts: {} })
+    const { data: registrationResult } = await axios.post('/register')
+    expect(registrationResult).toEqual({
+      success: true,
+      message: 'users registered successfully.',
+    })
   })
 })


### PR DESCRIPTION
This PR adds the `HandlerCollection` class which can be used to create a collection of mocks for future reusability.

```typescript
const collection = new HandlerCollection()

collection.collect(
  new Handler()
    .onGet('/users')
    .reply(200, {
      users,
    })
    .as('getAllUsers'),  // use `as('...') to assign a name to handler

  new Handler()
    .onPost('/register')
    .reply(200, {
      success: true,
      message: 'users registered successfully.',
    })
    .as('register'),
)
```

Now we can use our `collection` with the `MockServer` instance and enable our prewritten handlers by their associated names:

```typescript

const server = new MockServer(MSWServerInstance, { collection })

test('example of using HandlerCollection ', () => {
  server.use('getAllUsers', 'register')

  // OR using `enable` as an alias for `use`
  server.enable('getAllUsers', 'register')

  // ...
})
