### PR TITLE
refactor: rename Handler to RestHandler

### DIFF
--- a/src/HandlerCollection.test.ts
+++ b/src/HandlerCollection.test.ts
@@ -1,8 +1,8 @@
-import { Handler } from './Handler'
+import { RestHandler } from './RestHandler'
 import { HandlerCollection } from './HandlerCollection'
 
 it('should be able to collect a single handler', () => {
-  const getAllUsersHandler = new Handler()
+  const getAllUsersHandler = new RestHandler()
     .onGet('/user')
     .reply(200)
     .as('getUsers')
@@ -14,12 +14,12 @@ it('should be able to collect a single handler', () => {
 })
 
 it('should be able to collect multiple handlers', () => {
-  const getAllUsersHandler = new Handler()
+  const getAllUsersHandler = new RestHandler()
     .onGet('/user')
     .reply(200)
     .as('getUsers')
 
-  const registrationHandler = new Handler()
+  const registrationHandler = new RestHandler()
     .onPost('/register')
     .reply(200, {
       success: true,
@@ -35,7 +35,7 @@ it('should be able to collect multiple handlers', () => {
 })
 
 it('should trow appropriate error when the handler does not have a name', () => {
-  const handlerWithoutName = new Handler().onGet('/user').reply(200)
+  const handlerWithoutName = new RestHandler().onGet('/user').reply(200)
 
   const collection = new HandlerCollection()
 

--- a/src/HandlerCollection.ts
+++ b/src/HandlerCollection.ts
@@ -1,13 +1,13 @@
-import { Handler } from './Handler'
+import { RestHandler } from './RestHandler'
 
 export class HandlerCollection {
-  private collection: Map<string, Handler>
+  private collection: Map<string, RestHandler>
 
   constructor() {
-    this.collection = new Map<string, Handler>()
+    this.collection = new Map<string, RestHandler>()
   }
 
-  collect(...handlers: Array<Handler>): void {
+  collect(...handlers: Array<RestHandler>): void {
     handlers.forEach((handler) => {
       const key = handler.name
 
@@ -23,7 +23,7 @@ export class HandlerCollection {
     })
   }
 
-  find(name: string): Handler {
+  find(name: string): RestHandler {
     const handler = this.collection.get(name)
 
     if (!handler) {

--- a/src/MockServer.test.ts
+++ b/src/MockServer.test.ts
@@ -2,7 +2,7 @@ import axios from 'axios'
 import { setupServer } from 'msw/node'
 import { MockServer } from './MockServer'
 import { HandlerCollection } from './HandlerCollection'
-import { Handler } from './Handler'
+import { RestHandler } from './RestHandler'
 
 const mockServer = setupServer()
 
@@ -13,14 +13,14 @@ afterEach(() => mockServer.resetHandlers())
 const collection = new HandlerCollection()
 
 collection.collect(
-  new Handler()
+  new RestHandler()
     .onGet('/users')
     .reply(200, {
       users: [],
     })
     .as('getAllUsers'),
 
-  new Handler()
+  new RestHandler()
     .onPost('/register')
     .reply(200, {
       success: true,
@@ -91,7 +91,7 @@ describe('Using a collection', () => {
 describe('Using inline handlers', () => {
   it('should be able to enable an inline handler', async () => {
     server.use(
-      new Handler().onGet('/users').reply(200, {
+      new RestHandler().onGet('/users').reply(200, {
         users: [],
       }),
     )
@@ -102,13 +102,13 @@ describe('Using inline handlers', () => {
 
   it('should be able to enable multiple inline handlers', async () => {
     server.use(
-      new Handler().onGet('/users').reply(200, {
+      new RestHandler().onGet('/users').reply(200, {
         users: [],
       }),
     )
 
     server.use(
-      new Handler().onPost('/register').reply(200, {
+      new RestHandler().onPost('/register').reply(200, {
         success: true,
         message: 'users registered successfully.',
       }),
@@ -126,11 +126,11 @@ describe('Using inline handlers', () => {
 
   it('should be able to enable multiple inline handlers at once', async () => {
     server.use(
-      new Handler().onGet('/users').reply(200, {
+      new RestHandler().onGet('/users').reply(200, {
         users: [],
       }),
 
-      new Handler().onPost('/register').reply(200, {
+      new RestHandler().onPost('/register').reply(200, {
         success: true,
         message: 'users registered successfully.',
       }),

--- a/src/MockServer.ts
+++ b/src/MockServer.ts
@@ -1,7 +1,7 @@
 import type { SetupWorkerApi } from 'msw'
 import type { SetupServerApi } from 'msw/node'
 import type { HandlerCollection } from './HandlerCollection'
-import { Handler } from './Handler'
+import { RestHandler } from './RestHandler'
 
 interface MockServerOptions {
   collection: HandlerCollection
@@ -23,10 +23,10 @@ export class MockServer {
     }
   }
 
-  use(...handlers: Array<string> | Array<Handler>) {
+  use(...handlers: Array<string> | Array<RestHandler>) {
     if (Array.isArray(handlers)) {
       handlers.forEach((handler) => {
-        if (handler instanceof Handler) {
+        if (handler instanceof RestHandler) {
           return this.enableHandlerInstance(handler)
         }
 
@@ -39,7 +39,7 @@ export class MockServer {
     return this.use(...handlers)
   }
 
-  private enableHandlerInstance(handler: Handler) {
+  private enableHandlerInstance(handler: RestHandler) {
     return this.server.use(handler.run())
   }
 

--- a/src/RestHandler.ts
+++ b/src/RestHandler.ts
@@ -1,4 +1,4 @@
-import { RestHandler, RESTMethods } from 'msw'
+import { RestHandler as MSWRestHandler, RESTMethods } from 'msw'
 import {
   AsyncResponseResolverReturnType,
   defaultContext,
@@ -24,7 +24,7 @@ type ResponseResolver<
   context: ContextType
 }) => AsyncResponseResolverReturnType<MockedResponse<BodyType>>
 
-export class Handler<ResponseBody = unknown, RequestPayload = unknown> {
+export class RestHandler<ResponseBody = unknown, RequestPayload = unknown> {
   private method: RESTMethods = RESTMethods.GET
 
   private url?: string
@@ -82,13 +82,13 @@ export class Handler<ResponseBody = unknown, RequestPayload = unknown> {
 
   withPayload<Payload extends RequestPayload>(payload: Payload) {
     this.requestPayload = payload
-    return this as unknown as Handler<ResponseBody, Payload>
+    return this as unknown as RestHandler<ResponseBody, Payload>
   }
 
   public reply<Body extends ResponseBody>(status: number, body?: Body) {
     this.responseStatusCode = status
     this.responseBody = body
-    return this as unknown as Handler<Body, RequestPayload>
+    return this as unknown as RestHandler<Body, RequestPayload>
   }
 
   public resolve<
@@ -114,7 +114,7 @@ export class Handler<ResponseBody = unknown, RequestPayload = unknown> {
   run() {
     if (!this.url) throw new Error('No url provided')
 
-    return new RestHandler(
+    return new MSWRestHandler(
       this.method,
       this.url,
       (request, response, context) => {


### PR DESCRIPTION
The Handler class has been renamed to RestHandler in order to be able to support GraphQL in the future.